### PR TITLE
Add check for missing filetypes

### DIFF
--- a/src/Cogs/RepostCog.py
+++ b/src/Cogs/RepostCog.py
@@ -74,8 +74,10 @@ class Cog(commands.Cog):
         
     async def Add(self, msg: discord.Message, Attachment: discord.Attachment):
         File = await Attachment.read()
-        Type = Attachment.content_type.split("/")[0]
+        if not Attachment.content_type:
+            return
 
+        Type = Attachment.content_type.split("/")[0]
         if Type == "image":
             Reposts.AddImage(msg.id, msg.guild.id, File)
         elif Type == "video":
@@ -83,6 +85,10 @@ class Cog(commands.Cog):
 
     async def AssessAttachments(self,Attachments:List[discord.Attachment]) -> Tuple[str,discord.Attachment]:
         for Attachment in Attachments:
+            if not Attachment.content_type:
+                Log.debug(f"File ignored due to missing filetype")
+                continue
+
             Type = Attachment.content_type.split("/")[0]
             if Attachment.size > 4_000_000:
                 Log.debug(f"File ignored due to size of {Attachment.size} bytes")


### PR DESCRIPTION
Fixes the below error which occurs when sending files without an extension:
```
Ignoring exception in on_message
Traceback (most recent call last):
  File "/home/tom/PureImage/src/venv/lib/python3.10/site-packages/discord/client.py", line 343, in _run_event
    await coro(*args, **kwargs)
  File "/home/tom/PureImage/src/Cogs/RepostCog.py", line 27, in on_message
    async for Type,Attachment in self.AssessAttachments(msg.attachments):
  File "/home/tom/PureImage/src/Cogs/RepostCog.py", line 86, in AssessAttachments
    Type = Attachment.content_type.split("/")[0]
AttributeError: 'NoneType' object has no attribute 'split'
```