### PR TITLE
Fix null result error when checking videos

### DIFF
--- a/src/Modules/Reposts.py
+++ b/src/Modules/Reposts.py
@@ -113,7 +113,7 @@ def CheckVideo(guildID, file: bytes) -> Tuple[bool,Union[int,None]]:
                 MESSAGES.GuildID = ? and HASHES.Hash = ? and HASHES.Type = 'video'
         """, (guildID, NewHash))
     Hash = Hashes.fetchone()
-    if len(Hash) > 0:
-        return True,Hashes[0]
+    if Hash and len(Hash) > 0:
+        return True, Hash[0]
     else:
-        return False,None
+        return False, None


### PR DESCRIPTION
When testing and a video is received, the below error pops up.
```
[2022-07-24 08:16:19,444] Resposts: Exception in CheckVideo(751321295647670344, "<class 'bytes'>"):
Traceback (most recent call last):
  File "/home/tom/PureImage/src/Modules/Reposts.py", line 31, in Wrapper
    ReturnValue = func(*args, **kwargs)
  File "/home/tom/PureImage/src/Modules/Reposts.py", line 117, in CheckVideo
    return True,Hashes[0]
TypeError: 'sqlite3.Cursor' object is not subscriptable
Ignoring exception in on_message
Traceback (most recent call last):
  File "/home/tom/PureImage/src/venv/lib/python3.10/site-packages/discord/client.py", line 343, in _run_event
    await coro(*args, **kwargs)
  File "/home/tom/PureImage/src/Cogs/RepostCog.py", line 34, in on_message
    exists, OriginID = Reposts.CheckVideo(msg.guild.id, File)
TypeError: cannot unpack non-iterable NoneType object
```

It looks as though this was caused by a variable name typo. A follow-up error also occurs if there aren't any message IDs returned from the query, so `Hash` is null checked as well.